### PR TITLE
dont display success msg if an error occurs during checkout

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,12 +68,12 @@ module.exports = function gitBranchCheckout(exec, options) {
   }
 
   function onCheckout(branchName, err, stdout, stderr) {
-    validateExec(err, stdout, stderr);
-    result.emit('success', 'Switched to branch \'' + branchName.trim() + '\'');
+    if(!validateExec(err, stdout, stderr)){
+      result.emit('success', 'Switched to branch \'' + branchName.trim() + '\'');      
+    }
   }
 
   exec(('git branch ' + options.join(' ')).trim(), onGitBranch);
 
   return result;
 };
-


### PR DESCRIPTION
If checkout fails, it displays an error message, and a success message
success message shouldnt be there, since we didnt actually change branches
